### PR TITLE
扩展exstrings函数

### DIFF
--- a/exbytes/bytes.go
+++ b/exbytes/bytes.go
@@ -17,6 +17,8 @@ package exbytes
 
 import (
 	"bytes"
+
+	"github.com/thinkeridea/go-extend/exunicode/exutf8"
 )
 
 /*
@@ -67,4 +69,16 @@ func Reverse(s []byte) {
 	for i, j := 0, len(s)-1; i < len(s)/2; i, j = i+1, j-1 {
 		s[i], s[j] = s[j], s[i]
 	}
+}
+
+// Sub 是 exutf8.RuneSub 的别名，提供字符数量截取字节数组的方法，针对多字节字符安全高效的截取
+// 如果 start 是非负数，返回的字符串将从 string 的 start 位置开始，从 0 开始计算。例如，在字符串 “abcdef” 中，在位置 0 的字符是 “a”，位置 2 的字符串是 “c” 等等。
+// 如果 start 是负数，返回的字符串将从 string 结尾处向前数第 start 个字符开始。
+// 如果 string 的长度小于 start，将返回空字符串。
+//
+// 如果提供了正数的 length，返回的字符串将从 start 处开始最多包括 length 个字符（取决于 string 的长度）。
+// 如果提供了负数的 length，那么 string 末尾处的 length 个字符将会被省略（若 start 是负数则从字符串尾部算起）。如果 start 不在这段文本中，那么将返回空字符串。
+// 如果提供了值为 0 的 length，返回的子字符串将从 start 位置开始直到字符串结尾。
+func Sub(p []byte, start, length int) []byte {
+	return exutf8.RuneSub(p, start, length)
 }

--- a/exbytes/bytes_test.go
+++ b/exbytes/bytes_test.go
@@ -68,3 +68,28 @@ func TestReverse(t *testing.T) {
 		t.Errorf("Reverse(%q) = %q, want %q", []byte{1, 2, 3, 4, 5, 6, 7, 8, 9}, s, []byte{9, 8, 7, 6, 5, 4, 3, 2, 1})
 	}
 }
+
+func TestSub(t *testing.T) {
+	s := "Go（又称Golang）是Google开发的一种静态强类型、编译型、并发型，并具有垃圾回收功能的编程语言"
+	for _, tt := range []struct {
+		start, length int
+		in, out       string
+	}{
+		{-1, 0, s, "言"},
+		{-2, 0, s, "语言"},
+		{-3, 1, s, "程"},
+		{-3, -1, s, "程语"},
+		{0, -1, s, "Go（又称Golang）是Google开发的一种静态强类型、编译型、并发型，并具有垃圾回收功能的编程语"},
+		{2, -1, s, "（又称Golang）是Google开发的一种静态强类型、编译型、并发型，并具有垃圾回收功能的编程语"},
+		{52, 52, s, ""},
+		{3, 5, s, "又称Gol"},
+		{1, 0, s, "o（又称Golang）是Google开发的一种静态强类型、编译型、并发型，并具有垃圾回收功能的编程语言"},
+		{0, 10000, "", ""},
+		{-10000, 10000, s, ""},
+		{0, -10000, s, ""},
+	} {
+		if out := Sub([]byte(tt.in), tt.start, tt.length); string(out) != tt.out {
+			t.Errorf("RuneSub(%q, %d, %d) = %s, want %s", tt.in, tt.start, tt.length, out, tt.out)
+		}
+	}
+}

--- a/exstrings/benchmark/convert_test.go
+++ b/exstrings/benchmark/convert_test.go
@@ -1,0 +1,24 @@
+package benchmark
+
+import (
+	"testing"
+
+	"github.com/thinkeridea/go-extend/exstrings"
+)
+
+func BenchmarkStandardLibraryStringToBytes(b *testing.B) {
+	s := "Go语言是Google开发的一种静态强类型、编译型、并发型，并具有垃圾回收功能的编程语言。为了方便搜索和识别，有时会将其称为Golang。"
+	for i := 0; i < b.N; i++ {
+		p := []byte(s)
+		_ = p
+
+	}
+}
+
+func BenchmarkExstringsStringToBytes(b *testing.B) {
+	s := "Go语言是Google开发的一种静态强类型、编译型、并发型，并具有垃圾回收功能的编程语言。为了方便搜索和识别，有时会将其称为Golang。"
+	for i := 0; i < b.N; i++ {
+		p := exstrings.Bytes(s)
+		_ = p
+	}
+}

--- a/exstrings/benchmark/reverse_test.go
+++ b/exstrings/benchmark/reverse_test.go
@@ -1,0 +1,75 @@
+package benchmark
+
+import (
+	"testing"
+	"unicode/utf8"
+
+	"github.com/thinkeridea/go-extend/exbytes"
+	"github.com/thinkeridea/go-extend/exstrings"
+)
+
+func ReverseRunes(s string) string {
+	r := []rune(s)
+	for i, j := 0, len(r)-1; i < len(r)/2; i, j = i+1, j-1 {
+		r[i], r[j] = r[j], r[i]
+	}
+	return string(r)
+}
+
+func ReverseRange(s string) string {
+	n := len(s)
+	buf := make([]byte, n)
+	var start, end int
+	for _, r := range s {
+		l := utf8.RuneLen(r)
+		n -= l
+		end = start + l
+		copy(buf[n:], s[start:end])
+		start = end
+	}
+
+	return exbytes.ToString(buf)
+}
+
+func ReverseUTF8DecodeRuneInString(s string) string {
+	n := len(s)
+	buf := make([]byte, n)
+	var start, size, end int
+	for i := 0; i < len(s[start:]); {
+		_, size = utf8.DecodeRuneInString(s[start:])
+		n -= size
+		end = start + size
+		copy(buf[n:], s[start:end])
+		start = end
+	}
+
+	return exbytes.ToString(buf)
+}
+
+func BenchmarkReverseRunes(b *testing.B) {
+	s := "Go语言是Google开发的一种静态强类型、编译型、并发型，并具有垃圾回收功能的编程语言。为了方便搜索和识别，有时会将其称为Golang。"
+	for i := 0; i < b.N; i++ {
+		ReverseRunes(s)
+	}
+}
+
+func BenchmarkReverseRange(b *testing.B) {
+	s := "Go语言是Google开发的一种静态强类型、编译型、并发型，并具有垃圾回收功能的编程语言。为了方便搜索和识别，有时会将其称为Golang。"
+	for i := 0; i < b.N; i++ {
+		ReverseRange(s)
+	}
+}
+
+func BenchmarkReverseUTF8DecodeRuneInString(b *testing.B) {
+	s := "Go语言是Google开发的一种静态强类型、编译型、并发型，并具有垃圾回收功能的编程语言。为了方便搜索和识别，有时会将其称为Golang。"
+	for i := 0; i < b.N; i++ {
+		ReverseUTF8DecodeRuneInString(s)
+	}
+}
+
+func BenchmarkExstringsReverse(b *testing.B) {
+	s := "Go语言是Google开发的一种静态强类型、编译型、并发型，并具有垃圾回收功能的编程语言。为了方便搜索和识别，有时会将其称为Golang。"
+	for i := 0; i < b.N; i++ {
+		exstrings.Reverse(s)
+	}
+}

--- a/exstrings/convert.go
+++ b/exstrings/convert.go
@@ -70,3 +70,18 @@ func UnsafeToBytes(s string) []byte {
 		Cap:  strHeader.Len,
 	}))
 }
+
+/*
+Bytes 把字符串转换成 []byte 类型，和 []byte(s) 操作结果一致，但是效率更高。
+
+我进行了性能测试，它相比 []byte(s) 性能提升大约 14%，这仅仅是个实验的函数，它可能随着编译器优化而失去性能优势。
+极端性能情况下依然可以使用它，它永远和 []byte(s) 的结果一致。
+
+	BenchmarkStandardLibraryStringToBytes-8         18584335                58.4 ns/op           192 B/op          1 allocs/op
+	BenchmarkExstringsStringToBytes-8               23752122                50.1 ns/op           192 B/op          1 allocs/op
+*/
+func Bytes(s string) []byte {
+	buf := make([]byte, len(s))
+	copy(buf, s)
+	return buf
+}

--- a/exstrings/convert_test.go
+++ b/exstrings/convert_test.go
@@ -52,3 +52,15 @@ func TestUnsafeToBytes(t *testing.T) {
 		t.Fatalf("string(b)=%s s=%s", string(b), s)
 	}
 }
+
+func TestBytes(t *testing.T) {
+	for _, in := range []string{
+		"abcd",
+		"☺☻☹",
+		"☺☻☹",
+	} {
+		if p := Bytes(in); !reflect.DeepEqual(p, []byte(in)) {
+			t.Fatalf("Bytes(%s)=%q want %q", in, p, []byte(in))
+		}
+	}
+}

--- a/exstrings/strings.go
+++ b/exstrings/strings.go
@@ -25,13 +25,11 @@ import (
 // 使用 utf8.DecodeRuneInString 改进性能，请见：https://github.com/thinkeridea/go-extend/issues/5
 func Reverse(s string) string {
 	var start, size, end int
-	n := len(s)
-	buf := make([]byte, n)
-	for i := 0; i < len(s[start:]); {
+	buf := make([]byte, len(s))
+	for end < len(s) {
 		_, size = utf8.DecodeRuneInString(s[start:])
-		n -= size
 		end = start + size
-		copy(buf[n:], s[start:end])
+		copy(buf[len(buf)-end:], s[start:end])
 		start = end
 	}
 

--- a/exstrings/strings.go
+++ b/exstrings/strings.go
@@ -19,6 +19,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/thinkeridea/go-extend/exbytes"
+	"github.com/thinkeridea/go-extend/exunicode/exutf8"
 )
 
 // Reverse 反转字符串，通过 https://golang.org/doc/code.html#Library 收集
@@ -99,4 +100,16 @@ func Copy(src string) string {
 	buf := make([]byte, len(src))
 	copy(buf, src)
 	return exbytes.ToString(buf)
+}
+
+// SubString 是 exutf8.RuneSubString 的别名，提供字符数量截取字符串的方法，针对多字节字符安全高效的截取
+// 如果 start 是非负数，返回的字符串将从 string 的 start 位置开始，从 0 开始计算。例如，在字符串 “abcdef” 中，在位置 0 的字符是 “a”，位置 2 的字符串是 “c” 等等。
+// 如果 start 是负数，返回的字符串将从 string 结尾处向前数第 start 个字符开始。
+// 如果 string 的长度小于 start，将返回空字符串。
+//
+// 如果提供了正数的 length，返回的字符串将从 start 处开始最多包括 length 个字符（取决于 string 的长度）。
+// 如果提供了负数的 length，那么 string 末尾处的 length 个字符将会被省略（若 start 是负数则从字符串尾部算起）。如果 start 不在这段文本中，那么将返回空字符串。
+// 如果提供了值为 0 的 length，返回的子字符串将从 start 位置开始直到字符串结尾。
+func SubString(s string, start, length int) string {
+	return exutf8.RuneSubString(s, start, length)
 }

--- a/exstrings/strings_test.go
+++ b/exstrings/strings_test.go
@@ -235,3 +235,28 @@ func TestCopy(t *testing.T) {
 		t.Errorf("testString pointer address == s pointer address")
 	}
 }
+
+func TestSubString(t *testing.T) {
+	s := "Go（又称Golang）是Google开发的一种静态强类型、编译型、并发型，并具有垃圾回收功能的编程语言"
+	for _, tt := range []struct {
+		start, length int
+		in, out       string
+	}{
+		{-1, 0, s, "言"},
+		{-2, 0, s, "语言"},
+		{-3, 1, s, "程"},
+		{-3, -1, s, "程语"},
+		{0, -1, s, "Go（又称Golang）是Google开发的一种静态强类型、编译型、并发型，并具有垃圾回收功能的编程语"},
+		{2, -1, s, "（又称Golang）是Google开发的一种静态强类型、编译型、并发型，并具有垃圾回收功能的编程语"},
+		{52, 52, s, ""},
+		{3, 5, s, "又称Gol"},
+		{1, 0, s, "o（又称Golang）是Google开发的一种静态强类型、编译型、并发型，并具有垃圾回收功能的编程语言"},
+		{0, 10000, "", ""},
+		{-10000, 10000, s, ""},
+		{0, -10000, s, ""},
+	} {
+		if out := SubString(tt.in, tt.start, tt.length); out != tt.out {
+			t.Errorf("RuneSubstring(%q, %d, %d) = %s, want %s", tt.in, tt.start, tt.length, out, tt.out)
+		}
+	}
+}


### PR DESCRIPTION
- 优化 exstrings.Reverse 方法，使其代码更加易读，并进行多种反转字符串方法性能对比，其测试代码在[exstrings/benchmark/reverse_test.go](https://github.com/thinkeridea/go-extend/tree/master/exstrings/benchmark/reverse_test.go)， 其中`BenchmarkReverseUTF8DecodeRuneInString` 是优化前版本，  `BenchmarkExstringsReverse` 是优化有版本，性能提升约3%，其结果如下：

```shell
$ go test -benchmem -bench="Reverse"  
goos: darwin
goarch: amd64
pkg: github.com/thinkeridea/go-extend/exstrings/benchmark
BenchmarkReverseRunes-8                           703830              1700 ns/op             480 B/op          2 allocs/op
BenchmarkReverseRange-8                          1400299               861 ns/op             192 B/op          1 allocs/op
BenchmarkReverseUTF8DecodeRuneInString-8         1482175               717 ns/op             192 B/op          1 allocs/op
BenchmarkExstringsReverse-8                      1698225               694 ns/op             192 B/op          1 allocs/op
PASS
ok      github.com/thinkeridea/go-extend/exstrings/benchmark    7.995s
```

- 创建一个 `exstrings.Bytes` 方法，用来替换 `[]byte(s)`，相比 `[]byte(s)`  转换类型提升 14%，这仅仅是一个趣味函数，性能测试代码[exstrings/benchmark/convert_test.go](https://github.com/thinkeridea/go-extend/tree/master/exstrings/benchmark/convert_test.go) 结果如下：

```shell
$ go test -benchmem -bench="StringToBytes"  
goos: darwin
goarch: amd64
pkg: github.com/thinkeridea/go-extend/exstrings/benchmark
BenchmarkStandardLibraryStringToBytes-8         19118637                64.0 ns/op           192 B/op          1 allocs/op
BenchmarkExstringsStringToBytes-8               22079703                55.1 ns/op           192 B/op          1 allocs/op
PASS
ok      github.com/thinkeridea/go-extend/exstrings/benchmark    4.426s
```

- 添加 `exutf8.RuneSub` 别名 `exbytes.Sub`
- 添加 `exutf8.RuneSubString` 别名 `exstrings.SubString`

