### PR TITLE
Update: UnsafeToBytes

### DIFF
--- a/exstrings/convert.go
+++ b/exstrings/convert.go
@@ -15,10 +15,7 @@
 
 package exstrings
 
-import (
-	"reflect"
-	"unsafe"
-)
+import "unsafe"
 
 /*
 UnsafeToBytes 把 string 转换为 []byte 没有多余的内存开销。
@@ -63,12 +60,12 @@ UnsafeToBytes 把 string 转换为 []byte 没有多余的内存开销。
 当然还有更多的使用方法，可以极大的提升我们程序的性能。
 */
 func UnsafeToBytes(s string) []byte {
-	strHeader := (*reflect.StringHeader)(unsafe.Pointer(&s))
-	return *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
-		Data: strHeader.Data,
-		Len:  strHeader.Len,
-		Cap:  strHeader.Len,
-	}))
+	return *(*[]byte)(unsafe.Pointer(
+		&struct {
+			string
+			Cap int
+		}{s, len(s)},
+	))
 }
 
 /*

--- a/exstrings/convert_test.go
+++ b/exstrings/convert_test.go
@@ -64,3 +64,10 @@ func TestBytes(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkUnsafeToBytes(b *testing.B) {
+	str := strings.Repeat("abc", 128)
+	for i := 0; i < b.N; i++ {
+		UnsafeToBytes(str)
+	}
+}


### PR DESCRIPTION
More faster
```
$ go test -count=50 -bench=BenchmarkUnsafeToBytes > old.txt
$ go test -count=50 -bench=BenchmarkUnsafeToBytes > new.txt

$ benchcmp old.txt new.txt           
benchmark                    old ns/op     new ns/op     delta
BenchmarkUnsafeToBytes-4     0.50          0.38          -22.78%
BenchmarkUnsafeToBytes-4     0.36          0.35          -2.77%
BenchmarkUnsafeToBytes-4     0.55          0.35          -35.75%
BenchmarkUnsafeToBytes-4     0.37          0.36          -4.03%
BenchmarkUnsafeToBytes-4     0.33          0.35          +4.50%
BenchmarkUnsafeToBytes-4     0.36          0.35          -2.79%
BenchmarkUnsafeToBytes-4     0.33          0.33          +0.60%
BenchmarkUnsafeToBytes-4     0.35          0.33          -5.17%
BenchmarkUnsafeToBytes-4     0.35          0.34          -4.51%
BenchmarkUnsafeToBytes-4     0.36          0.33          -8.94%
BenchmarkUnsafeToBytes-4     0.38          0.33          -13.09%
BenchmarkUnsafeToBytes-4     0.36          0.34          -5.28%
BenchmarkUnsafeToBytes-4     0.37          0.35          -5.08%
BenchmarkUnsafeToBytes-4     0.37          0.43          +14.75%
BenchmarkUnsafeToBytes-4     0.35          0.35          +0.29%
BenchmarkUnsafeToBytes-4     0.35          0.37          +7.23%
BenchmarkUnsafeToBytes-4     0.39          0.36          -7.24%
BenchmarkUnsafeToBytes-4     0.36          0.36          -0.28%
BenchmarkUnsafeToBytes-4     0.35          0.35          +0.57%
BenchmarkUnsafeToBytes-4     0.35          0.34          -3.97%
BenchmarkUnsafeToBytes-4     0.34          0.34          -0.29%
BenchmarkUnsafeToBytes-4     0.33          0.35          +6.01%
BenchmarkUnsafeToBytes-4     0.39          0.34          -14.10%
BenchmarkUnsafeToBytes-4     0.55          0.34          -38.84%
BenchmarkUnsafeToBytes-4     0.41          0.34          -17.23%
BenchmarkUnsafeToBytes-4     0.38          0.36          -2.67%
BenchmarkUnsafeToBytes-4     0.37          0.38          +2.71%
BenchmarkUnsafeToBytes-4     0.37          0.34          -7.65%
BenchmarkUnsafeToBytes-4     0.42          0.34          -18.25%
BenchmarkUnsafeToBytes-4     0.37          0.37          -1.88%
BenchmarkUnsafeToBytes-4     0.37          0.36          -2.73%
BenchmarkUnsafeToBytes-4     0.41          0.35          -14.56%
BenchmarkUnsafeToBytes-4     0.35          0.35          +2.31%
BenchmarkUnsafeToBytes-4     0.35          0.36          +1.98%
BenchmarkUnsafeToBytes-4     0.37          0.36          -2.72%
BenchmarkUnsafeToBytes-4     0.39          0.34          -11.11%
BenchmarkUnsafeToBytes-4     0.47          0.35          -26.27%
BenchmarkUnsafeToBytes-4     0.39          0.34          -11.40%
BenchmarkUnsafeToBytes-4     0.43          0.36          -16.47%
BenchmarkUnsafeToBytes-4     0.36          0.34          -5.22%
BenchmarkUnsafeToBytes-4     0.36          0.37          +0.82%
BenchmarkUnsafeToBytes-4     0.39          0.34          -12.73%
BenchmarkUnsafeToBytes-4     0.40          0.36          -9.00%
BenchmarkUnsafeToBytes-4     0.39          0.34          -13.55%
BenchmarkUnsafeToBytes-4     0.36          0.40          +11.36%
BenchmarkUnsafeToBytes-4     0.60          0.36          -40.73%
BenchmarkUnsafeToBytes-4     0.36          0.34          -6.58%
BenchmarkUnsafeToBytes-4     0.38          0.33          -12.37%
BenchmarkUnsafeToBytes-4     0.39          0.33          -13.47%
BenchmarkUnsafeToBytes-4     0.39          0.34          -13.40%
```