### PR TITLE
调优exmath.Round算法

### DIFF
--- a/exmath/benchmark/round_test.go
+++ b/exmath/benchmark/round_test.go
@@ -1,0 +1,14 @@
+package benchmark
+
+import (
+	"testing"
+
+	"github.com/thinkeridea/go-extend/exmath"
+)
+
+func BenchmarkRound(b *testing.B) {
+	f := 0.15807659924030304
+	for i := 0; i < b.N; i++ {
+		_ = exmath.Round(f, 5)
+	}
+}

--- a/exmath/round.go
+++ b/exmath/round.go
@@ -11,5 +11,5 @@ import (
 // 返回将 val 根据指定精度 precision（十进制小数点后数字的数目）进行四舍五入的结果。precision 也可以是负数或零。
 func Round(val float64, precision int) float64 {
 	p := math.Pow10(precision)
-	return math.Floor((val+(0.5/p))*p) / p
+	return math.Floor(val*p+0.5) / p
 }

--- a/exmath/round_test.go
+++ b/exmath/round_test.go
@@ -65,3 +65,4 @@ func TestRound(t *testing.T) {
 		}
 	}
 }
+


### PR DESCRIPTION
调优 `exmath.Round` 算法，获得接近 16% 的性能提升

$ benchstat old.txt new.txt

name     old time/op  new time/op  delta
Round-8  4.20ns ± 3%  3.50ns ± 4%  -16.69%  (p=0.000 n=44+49)

$ benchcmp old.txt new.txt

benchcmp is deprecated in favor of benchstat: https://pkg.go.dev/golang.org/x/perf/cmd/benchstat
benchmark            old ns/op     new ns/op     delta
BenchmarkRound-8     5.50          3.55          -35.45%
BenchmarkRound-8     4.50          3.49          -22.44%
BenchmarkRound-8     4.45          3.47          -22.02%
BenchmarkRound-8     4.35          3.57          -17.93%
BenchmarkRound-8     4.56          3.45          -24.34%
BenchmarkRound-8     4.84          3.47          -28.31%
BenchmarkRound-8     4.19          3.46          -17.42%
BenchmarkRound-8     4.16          3.47          -16.59%
BenchmarkRound-8     4.16          3.48          -16.35%
BenchmarkRound-8     4.17          3.48          -16.55%
BenchmarkRound-8     4.16          3.46          -16.83%
BenchmarkRound-8     4.18          3.48          -16.75%
BenchmarkRound-8     4.19          3.48          -16.95%
BenchmarkRound-8     4.23          3.47          -17.97%
BenchmarkRound-8     4.18          3.56          -14.83%
BenchmarkRound-8     4.23          3.71          -12.29%
BenchmarkRound-8     4.14          3.60          -13.04%
BenchmarkRound-8     4.18          3.62          -13.40%
BenchmarkRound-8     4.19          3.58          -14.56%
BenchmarkRound-8     4.30          3.59          -16.51%
BenchmarkRound-8     4.27          3.53          -17.33%
BenchmarkRound-8     4.25          3.47          -18.35%
BenchmarkRound-8     4.29          3.46          -19.35%
BenchmarkRound-8     4.24          3.47          -18.16%
BenchmarkRound-8     4.23          3.57          -15.60%
BenchmarkRound-8     4.16          3.47          -16.59%
BenchmarkRound-8     4.23          3.56          -15.84%
BenchmarkRound-8     4.24          3.58          -15.57%
BenchmarkRound-8     4.19          3.48          -16.95%
BenchmarkRound-8     4.22          3.46          -18.01%
BenchmarkRound-8     4.19          3.48          -16.95%
BenchmarkRound-8     4.23          3.46          -18.20%
BenchmarkRound-8     4.17          3.47          -16.79%
BenchmarkRound-8     4.25          3.63          -14.59%
BenchmarkRound-8     4.17          3.47          -16.79%
BenchmarkRound-8     4.14          3.46          -16.43%
BenchmarkRound-8     4.21          3.46          -17.81%
BenchmarkRound-8     4.15          3.47          -16.39%
BenchmarkRound-8     4.23          3.44          -18.68%
BenchmarkRound-8     4.18          3.48          -16.75%
BenchmarkRound-8     4.17          3.46          -17.03%
BenchmarkRound-8     4.20          3.47          -17.38%
BenchmarkRound-8     4.33          3.47          -19.86%
BenchmarkRound-8     4.19          3.47          -17.18%
BenchmarkRound-8     4.17          3.48          -16.55%
BenchmarkRound-8     4.18          3.52          -15.79%
BenchmarkRound-8     4.17          3.49          -16.31%
BenchmarkRound-8     4.19          3.47          -17.18%
BenchmarkRound-8     4.17          3.47          -16.79%
BenchmarkRound-8     4.16          3.57          -14.18%
