### PR TITLE
动态评估bytes.Buffer的需求的容量，全局共享bytes.Buffer池

### DIFF
--- a/exstrings/join_int.go
+++ b/exstrings/join_int.go
@@ -9,144 +9,87 @@ import (
 	"github.com/thinkeridea/go-extend/pool"
 )
 
-var buffPool = pool.GetBuff64()
+var buffPool = pool.NewBuffer(64)
 
 // JoinInts 使用 sep 连接 []int 并返回连接的字符串
-func JoinInts(i []int, sep string) string {
-	buf := buffPool.Get()
-	for _, v := range i {
-		if buf.Len() > 0 {
-			buf.WriteString(sep)
-		}
-		buf.WriteString(strconv.FormatInt(int64(v), 10))
-	}
-
-	buffPool.Put(buf)
-	return buf.String()
+func JoinInts(v []int, sep string) string {
+	return joinInts(len(v), sep, func(i int) string {
+		return strconv.FormatInt(int64(v[i]), 10)
+	})
 }
 
 // JoinInt8s 使用 sep 连接 []int8 并返回连接的字符串
-func JoinInt8s(i []int8, sep string) string {
-	buf := buffPool.Get()
-	for _, v := range i {
-		if buf.Len() > 0 {
-			buf.WriteString(sep)
-		}
-		buf.WriteString(strconv.FormatInt(int64(v), 10))
-	}
-
-	buffPool.Put(buf)
-	return buf.String()
+func JoinInt8s(v []int8, sep string) string {
+	return joinInts(len(v), sep, func(i int) string {
+		return strconv.FormatInt(int64(v[i]), 10)
+	})
 }
 
 // JoinInt16s 使用 sep 连接 []int16 并返回连接的字符串
-func JoinInt16s(i []int16, sep string) string {
-	buf := buffPool.Get()
-	for _, v := range i {
-		if buf.Len() > 0 {
-			buf.WriteString(sep)
-		}
-		buf.WriteString(strconv.FormatInt(int64(v), 10))
-	}
-
-	buffPool.Put(buf)
-	return buf.String()
+func JoinInt16s(v []int16, sep string) string {
+	return joinInts(len(v), sep, func(i int) string {
+		return strconv.FormatInt(int64(v[i]), 10)
+	})
 }
 
 // JoinInt32s 使用 sep 连接 []int32 并返回连接的字符串
-func JoinInt32s(i []int32, sep string) string {
-	buf := buffPool.Get()
-	for _, v := range i {
-		if buf.Len() > 0 {
-			buf.WriteString(sep)
-		}
-		buf.WriteString(strconv.FormatInt(int64(v), 10))
-	}
-
-	buffPool.Put(buf)
-	return buf.String()
+func JoinInt32s(v []int32, sep string) string {
+	return joinInts(len(v), sep, func(i int) string {
+		return strconv.FormatInt(int64(v[i]), 10)
+	})
 }
 
 // JoinInt64s 使用 sep 连接 []int64 并返回连接的字符串
-func JoinInt64s(i []int64, sep string) string {
-	buf := buffPool.Get()
-	for _, v := range i {
-		if buf.Len() > 0 {
-			buf.WriteString(sep)
-		}
-		buf.WriteString(strconv.FormatInt(v, 10))
-	}
-
-	buffPool.Put(buf)
-	return buf.String()
+func JoinInt64s(v []int64, sep string) string {
+	return joinInts(len(v), sep, func(i int) string {
+		return strconv.FormatInt(v[i], 10)
+	})
 }
 
 // JoinUints 使用 sep 连接 []uint 并返回连接的字符串
-func JoinUints(i []uint, sep string) string {
-	buf := buffPool.Get()
-	for _, v := range i {
-		if buf.Len() > 0 {
-			buf.WriteString(sep)
-		}
-		buf.WriteString(strconv.FormatUint(uint64(v), 10))
-	}
-
-	buffPool.Put(buf)
-	return buf.String()
+func JoinUints(v []uint, sep string) string {
+	return joinInts(len(v), sep, func(i int) string {
+		return strconv.FormatUint(uint64(v[i]), 10)
+	})
 }
 
 // JoinUint8s 使用 sep 连接 []uint8 并返回连接的字符串
-func JoinUint8s(i []uint8, sep string) string {
-	buf := buffPool.Get()
-	for _, v := range i {
-		if buf.Len() > 0 {
-			buf.WriteString(sep)
-		}
-		buf.WriteString(strconv.FormatUint(uint64(v), 10))
-	}
-
-	buffPool.Put(buf)
-	return buf.String()
+func JoinUint8s(v []uint8, sep string) string {
+	return joinInts(len(v), sep, func(i int) string {
+		return strconv.FormatUint(uint64(v[i]), 10)
+	})
 }
 
 // JoinUint16s 使用 sep 连接 []uint16 并返回连接的字符串
-func JoinUint16s(i []uint16, sep string) string {
-	buf := buffPool.Get()
-	for _, v := range i {
-		if buf.Len() > 0 {
-			buf.WriteString(sep)
-		}
-		buf.WriteString(strconv.FormatUint(uint64(v), 10))
-	}
-
-	buffPool.Put(buf)
-	return buf.String()
+func JoinUint16s(v []uint16, sep string) string {
+	return joinInts(len(v), sep, func(i int) string {
+		return strconv.FormatUint(uint64(v[i]), 10)
+	})
 }
 
 // JoinUint32s 使用 sep 连接 []uint32 并返回连接的字符串
-func JoinUint32s(i []uint32, sep string) string {
-	buf := buffPool.Get()
-	for _, v := range i {
-		if buf.Len() > 0 {
-			buf.WriteString(sep)
-		}
-		buf.WriteString(strconv.FormatUint(uint64(v), 10))
-	}
-
-	buffPool.Put(buf)
-	return buf.String()
+func JoinUint32s(v []uint32, sep string) string {
+	return joinInts(len(v), sep, func(i int) string {
+		return strconv.FormatUint(uint64(v[i]), 10)
+	})
 }
 
 // JoinUint64s 使用 sep 连接 []uint64 并返回连接的字符串
-func JoinUint64s(i []uint64, sep string) string {
+func JoinUint64s(v []uint64, sep string) string {
+	return joinInts(len(v), sep, func(i int) string {
+		return strconv.FormatUint(v[i], 10)
+	})
+}
+
+func joinInts(n int, sep string, f func(i int) string) string {
 	buf := buffPool.Get()
-	for _, v := range i {
+	defer buffPool.Put(buf)
+	for i := 0; i < n; i++ {
 		if buf.Len() > 0 {
 			buf.WriteString(sep)
 		}
-		buf.WriteString(strconv.FormatUint(v, 10))
+		buf.WriteString(f(i))
 	}
 
-	buffPool.Put(buf)
 	return buf.String()
 }

--- a/pool/benchmark/buffer_test.go
+++ b/pool/benchmark/buffer_test.go
@@ -1,0 +1,98 @@
+package benchmark
+
+import (
+	"bytes"
+	"container/ring"
+	"math/rand"
+	"sync"
+	"testing"
+
+	"github.com/thinkeridea/go-extend/pool"
+)
+
+var bufferData = ring.New(256)
+
+func init() {
+	data := bufferData
+	for i := 0; i < 256; i++ {
+		data.Value = make([]byte, rand.Intn(1<<16))
+		data = data.Next()
+	}
+}
+
+func BenchmarkBufferPool(b *testing.B) {
+	buff := pool.NewBuffer(64)
+	p := [20]*bytes.Buffer{}
+	data := bufferData
+	for i := 0; i < b.N; i++ {
+		data.Next()
+		bf := buff.Get()
+		bf.Write(data.Value.([]byte))
+
+		idx := i % 20
+		if v := p[idx]; v != nil {
+			buff.Put(v)
+		}
+
+		p[idx] = bf
+	}
+}
+
+func BenchmarkBufferSyncPool(b *testing.B) {
+	buff := sync.Pool{New: func() interface{} {
+		return bytes.NewBuffer(make([]byte, 0, 64))
+	}}
+
+	p := [20]*bytes.Buffer{}
+	data := bufferData
+	for i := 0; i < b.N; i++ {
+		data.Next()
+		bf := buff.Get().(*bytes.Buffer)
+		bf.Write(data.Value.([]byte))
+
+		idx := i % 20
+		if v := p[idx]; v != nil {
+			buff.Put(v)
+		}
+
+		p[idx] = bf
+	}
+}
+
+// 用来测试在容量没有变化的情况下与原始方式的性能差异
+func BenchmarkBufferFixedSizePool(b *testing.B) {
+	buff := pool.NewBuffer(64)
+	p := [20]*bytes.Buffer{}
+	data := make([]byte, 50)
+	for i := 0; i < b.N; i++ {
+		bf := buff.Get()
+		bf.Write(data)
+
+		idx := i % 20
+		if v := p[idx]; v != nil {
+			buff.Put(v)
+		}
+
+		p[idx] = bf
+	}
+}
+
+func BenchmarkBufferFixedSizeSyncPool(b *testing.B) {
+	buff := sync.Pool{New: func() interface{} {
+		return bytes.NewBuffer(make([]byte, 0, 64))
+	}}
+
+	p := [20]*bytes.Buffer{}
+	data := make([]byte, 50)
+	for i := 0; i < b.N; i++ {
+		bf := buff.Get().(*bytes.Buffer)
+		bf.Write(data)
+
+		idx := i % 20
+		if v := p[idx]; v != nil {
+			buff.Put(v)
+		}
+
+		p[idx] = bf
+	}
+}

--- a/pool/buffer_test.go
+++ b/pool/buffer_test.go
@@ -8,6 +8,183 @@ import (
 	"testing"
 )
 
+func TestBuffer_Get(t *testing.T) {
+	p := NewBuffer(64)
+	b := p.Get()
+	if b.Cap() != 64 {
+		t.Errorf("b.Cap():%d != 64", b.Cap())
+	}
+
+	if b.Len() != 0 {
+		t.Errorf("b.String():%s != xx", b.String())
+	}
+
+	b.WriteString("xx")
+	if b.String() != "xx" {
+		t.Errorf("b.String():%s != xx", b.String())
+	}
+
+	// 开启 race 时有一定概率导致 Put 被丢弃
+	for i := 0; i < 10; i++ {
+		b = p.Get()
+		if b.Len() != 0 {
+			t.Errorf("b.String():%s != xx", b.String())
+		}
+
+		if b.Cap() != 64 {
+			t.Errorf("b.Cap():%d != 64", b.Cap())
+		}
+		p.Put(b)
+	}
+}
+
+func TestBuffer_Put(t *testing.T) {
+	p := NewBuffer(64)
+	b := p.Get()
+	b.WriteString("xx")
+	if b.String() != "xx" {
+		t.Errorf("b.String():%s != xx", b.String())
+	}
+
+	p.Put(b)
+
+	bufp := p.(*buffer)
+	if bufp.release != 1 {
+		t.Errorf("release:%d != 1", bufp.release)
+	}
+
+	if bufp.calls[0] != 1 {
+		t.Errorf("calls[0]:%d != 1", bufp.calls[0])
+	}
+
+	var bb *bytes.Buffer
+	// 开启 race 时有一定概率导致 Put 被丢弃
+	pp := buffBucket[0]
+	var n uint32 = 1
+	for i := 0; i < 10; i++ {
+		v := pp.Get()
+		if v == nil {
+			p.Put(b)
+			n++
+			continue
+		}
+
+		bb = v.(*bytes.Buffer)
+		if bb.String() == "xx" {
+			break
+		}
+
+		p.Put(b)
+		n++
+	}
+
+	if bb.String() != "xx" {
+		t.Errorf("b1.String():%s != xx", bb.String())
+	}
+
+	if bufp.release != n {
+		t.Errorf("release:%d != %d", bufp.release, n)
+	}
+
+	if bufp.calls[0] != n {
+		t.Errorf("calls[0]:%d != %d", bufp.calls[0], n)
+	}
+
+	p.Put(bytes.NewBuffer(make([]byte, 1024)))
+	if bufp.release != n+1 {
+		t.Errorf("release:%d != %d", bufp.release, n+1)
+	}
+
+	if bufp.calls[4] != 1 {
+		t.Errorf("calls[4]:%d != 1", bufp.calls[0])
+	}
+
+	for i := 0; i < bucketSize; i++ {
+		if i != 0 && i != 4 && bufp.calls[i] != 0 {
+			t.Errorf("calls[%d]:%d != 0", i, bufp.calls[0])
+		}
+	}
+}
+
+func TestBuffer_Calibrate(t *testing.T) {
+	p := NewBuffer(64)
+	for i := 0; i < 5; i++ {
+		for j := 0; j < 5; j++ {
+			p.Put(bytes.NewBuffer(make([]byte, minSize<<i)))
+		}
+	}
+
+	bufp := p.(*buffer)
+	bufp.release = calibrateCallsThreshold - 10
+	for i := 0; i < 11; i++ {
+		p.Put(bytes.NewBuffer(make([]byte, minSize<<5)))
+	}
+
+	if bufp.index != 5 {
+		t.Errorf("index:%d != 5", bufp.index)
+	}
+
+	if bufp.release != 0 {
+		t.Errorf("release:%d != 0", bufp.release)
+	}
+
+	if bufp.calibrating != 0 {
+		t.Errorf("calibrating:%d != 0", bufp.calibrating)
+	}
+
+	for i := 0; i < bucketSize; i++ {
+		if bufp.calls[i] != 0 {
+			t.Errorf("calls[%d]:%d != 0", i, bufp.calls[0])
+		}
+	}
+
+	bufp.calibrating = 1
+	bufp.release = calibrateCallsThreshold - 10
+	for i := 0; i < 11; i++ {
+		p.Put(bytes.NewBuffer(make([]byte, minSize)))
+	}
+
+	if bufp.index != 5 {
+		t.Errorf("index:%d != 5", bufp.index)
+	}
+
+	if bufp.release != 10241 {
+		t.Errorf("release:%d != 10241", bufp.release)
+	}
+
+	if bufp.calibrating != 1 {
+		t.Errorf("calibrating:%d != 1", bufp.calibrating)
+	}
+
+	if bufp.calls[0] != 11 {
+		t.Errorf("calls[0]:%d != 11", bufp.calls[0])
+	}
+}
+
+func TestBuffBucketIndexIndex(t *testing.T) {
+	var n int
+	for i := 0; i < minSizeBits+bucketSize+5; i++ {
+		n = 0
+		if i > minSizeBits {
+			n = i - minSizeBits
+		}
+
+		if n >= bucketSize {
+			n = bucketSize - 1
+		}
+
+		if idx := buffBucketIndex(1 << i); idx != n {
+			t.Errorf("index(%d) :%d = %d", 1<<i, idx, n)
+		}
+
+		if i > minSizeBits {
+			if idx := buffBucketIndex(1<<(i-1) + 1); idx != n {
+				t.Errorf("index(%d) :%d != %d", 1<<(i-1)+1, idx, n)
+			}
+		}
+	}
+}
+
 func TestGetBuff64(t *testing.T) {
 	p1 := GetBuff64()
 	p2 := GetBuff64()

--- a/pool/std_buffer.go
+++ b/pool/std_buffer.go
@@ -1,0 +1,22 @@
+package pool
+
+import (
+	"bytes"
+	"unsafe"
+)
+
+// stdBuffer 是 bytes.Buffer 的结构引用，这需要对各个go的版本进行测试，保证该结构的准确性
+type stdBuffer struct {
+	b   []byte
+	off int
+}
+
+// bufferLen 获取buf的实际使用长度， 默认使用 cap 作为降级方案
+func bufferLen(b *bytes.Buffer) int {
+	x := (*stdBuffer)(unsafe.Pointer(b))
+	if x.off+b.Len() == len(x.b) {
+		return len(x.b)
+	}
+
+	return b.Cap()
+}

--- a/pool/std_buffer_test.go
+++ b/pool/std_buffer_test.go
@@ -1,0 +1,40 @@
+package pool
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+	"unsafe"
+)
+
+func TestStdBuffer(t *testing.T) {
+	data := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+	buf := bytes.NewBuffer(make([]byte, 0, 20))
+	buf.Write(data)
+
+	r := make([]byte, 5)
+	buf.Read(r)
+
+	x := (*stdBuffer)(unsafe.Pointer(buf))
+	if !reflect.DeepEqual(x.b, data) {
+		t.Errorf("Buffer.buf(%v) != (%v)", x.b, data)
+	}
+
+	if x.off != 5 {
+		t.Errorf("Buffer.off(%d) != 5", x.off)
+	}
+}
+
+func TestBufferLen(t *testing.T) {
+	data := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+	buf := bytes.NewBuffer(make([]byte, 0, 20))
+	buf.Write(data)
+
+	r := make([]byte, 5)
+	buf.Read(r)
+
+	n := bufferLen(buf)
+	if n != 10 {
+		t.Errorf("bufferLen(%d) != 10", n)
+	}
+}


### PR DESCRIPTION
采用全局共享不同容量区间（采用2的幂次方来划分），一共 22 个区间，最小64 byte， 最大 256 MB， 根据动态计算，在获取 `bytes.Buffer` 时从相应桶的 `sync.Pool` 来获取，以减少多余的内存浪费及`bytes.Buffer` 扩容次数。

相较于使用固定容量的 `sync.Pool` 在需求容量动态波动时可以获取30~40倍的性能提升（这并不包含GC带来的性能提升，那将是更令人兴奋的），在内存分配上可以减少近300倍。

即使在每次都获取固定容量，且不发生扩容的情况（这会导致动态池只是用单个桶）， `sync.Pool`并没有带来很大的惊喜，动态池相较于 `sync.Pool` 性能略下降 28%， 单次约 17ns， 即使这样这依然让人振奋，大多数我们都在处理不同大小的数据，使用动态bytes.Buffer共享池我们将收益巨大。

```
goos: darwin
goarch: amd64
pkg: github.com/thinkeridea/go-extend/pool/benchmark
BenchmarkBufferPool
BenchmarkBufferPool-8                    1088794              1102 ns/op             387 B/op          0 allocs/op
BenchmarkBufferSyncPool
BenchmarkBufferSyncPool-8                  49735             37895 ns/op          115277 B/op          0 allocs/op
BenchmarkBufferFixedSizePool
BenchmarkBufferFixedSizePool-8          27296764                42.7 ns/op             0 B/op          0 allocs/op
BenchmarkBufferFixedSizeSyncPool
BenchmarkBufferFixedSizeSyncPool-8      26099842                59.6 ns/op           192 B/op          0 allocs/op
PASS
ok      github.com/thinkeridea/go-extend/pool/benchmark 8.627s
```