### PR TITLE
优化Round

### DIFF
--- a/exmath/round.go
+++ b/exmath/round.go
@@ -15,9 +15,6 @@ func Round(val float64, precision int) float64 {
 	}
 
 	p := math.Pow10(precision)
-	if precision < 0 {
-		return math.Floor(val*p+0.5) * math.Pow10(-precision)
-	}
 
 	return math.Floor(val*p+0.5) / p
 }


### PR DESCRIPTION
去掉判断后, 为负数时, 仍然正确

```
	if precision < 0 {
		return math.Floor(val*p+0.5) * math.Pow10(-precision)
	}
```